### PR TITLE
Ignore OSX binary created by macos/watcher.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.log
+autoload/lumen/platforms/macos/watcher


### PR DESCRIPTION
On OSX, the first execution of the plugin shows the error:
```
Error detected while processing /Users/dakeryas/.vim/pack/vendor/start/vim-lumen/plugin/lumen.vim[6]..function lumen#init[7]..lumen#oneshot[1]..lumen#platforms#call[10]..lumen#platforms#macos#oneshot:
line    1:
E684: List index out of range: 0
line    2:
E121: Undefined variable: out
E116: Invalid arguments for function len(out) != 5
line    6:
E121: Undefined variable: out
E116: Invalid arguments for function lumen#platforms#macos#parse_line
```

but it seems to create a `watcher` binary that can later be used and makes the error disappear. Nonetheless, one then has this binary file in the git status, hence my ignorining it with this `.gitignore` addition.